### PR TITLE
fix(CommandManager):out of bounds args spreadsheet command

### DIFF
--- a/src/main/java/me/dodas/financeplanner/managers/CommandManager.java
+++ b/src/main/java/me/dodas/financeplanner/managers/CommandManager.java
@@ -44,10 +44,12 @@ public class CommandManager {
         
         if (cmd.getSubcommands().length > 0) {     
             for(SubCommand scmd : cmd.getSubcommands()) {
-                if (scmd.getName().equals(args.get(0))) {
-                    args.remove(0);
-                    scmd.executeCommand(args);
-                    return;
+                if(args.size() > 0) {
+                    if (scmd.getName().equals(args.get(0))) {
+                        args.remove(0);
+                        scmd.executeCommand(args);
+                        return;
+                    }
                 }
             }
             System.out.println("Sub command not found.");


### PR DESCRIPTION
When executing a command with registered subcommands, without passing arguments, an 'out of bounds' error was triggered, since there was no check for the existence of elements in the argument list. Now, if the argument list is empty, nothing will happen.