### PR TITLE
fix:check spreadsheet existence before loading

### DIFF
--- a/src/main/java/me/dodas/financeplanner/managers/SpreadsheetManager.java
+++ b/src/main/java/me/dodas/financeplanner/managers/SpreadsheetManager.java
@@ -49,10 +49,13 @@ public class SpreadsheetManager {
             throw new IllegalStateException("The name is invalid. Use [-n, --sheet_name <name>].");
         }
 
-        /* FileManager está retornando null quando é tentado ler um arquivo com nome inexistente.
-         * É necessário adicionar uma verificação antes de chamar o método gson.fromJson.
-         */
-        loadedSpreadsheet = gson.fromJson(fileManager.readFile(String.format("%s/%s.json", spreadsheetDirectory, spreadsheetName)), Spreadsheet.class);
+        String path = String.format("%s/%s.json", spreadsheetDirectory, spreadsheetName);
+
+        if(!fileManager.checkFile(path)) {
+            throw new IllegalArgumentException(String.format("No spreadsheet named '%s' was found", spreadsheetName));
+        }
+
+        loadedSpreadsheet = gson.fromJson(fileManager.readFile(path), Spreadsheet.class);
     }
 
     public void closeSpreadsheet() {

--- a/src/main/java/me/dodas/financeplanner/subcommands/SpreadsheetLoadSubCommand.java
+++ b/src/main/java/me/dodas/financeplanner/subcommands/SpreadsheetLoadSubCommand.java
@@ -94,6 +94,10 @@ public class SpreadsheetLoadSubCommand implements SubCommand {
 
             System.out.println(ise.getMessage());
 
+        } catch (IllegalArgumentException iae) {
+
+            System.out.println(iae.getMessage());
+            
         }
     }
     


### PR DESCRIPTION
When trying to load a spreadsheet, if a non-existent name was used, the file read value was returned null. This caused a null Spreadsheet class to be instantiated. Now, before loading a file, an existence check is performed. If it exists, a Spreadsheet class is loaded. Otherwise, an exception is thrown.