### PR TITLE
fix:MonthlyRegister deserialization

### DIFF
--- a/src/main/java/me/dodas/financeplanner/managers/SpreadsheetManager.java
+++ b/src/main/java/me/dodas/financeplanner/managers/SpreadsheetManager.java
@@ -1,8 +1,11 @@
 package me.dodas.financeplanner.managers;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
+import me.dodas.financeplanner.models.MonthlyRegister;
 import me.dodas.financeplanner.models.Spreadsheet;
+import me.dodas.financeplanner.utils.MonthlyRegisterAdapter;
 
 public class SpreadsheetManager {
 
@@ -10,7 +13,7 @@ public class SpreadsheetManager {
     private FileManager fileManager = FileManager.getInstance();
     private DirectoryManager directoryManager = DirectoryManager.getInstance();
     private ConfigManager configManager = ConfigManager.getInstance();
-    private Gson gson = new Gson();
+    private Gson gson = new GsonBuilder().registerTypeAdapter(MonthlyRegister.class, new MonthlyRegisterAdapter()).create();
     private Spreadsheet loadedSpreadsheet;
     private String spreadsheetDirectory = String.format("%s/%s", directoryManager.getRootPath(), configManager.getProperty("directory.spreadsheet.root"));
 

--- a/src/main/java/me/dodas/financeplanner/models/Spreadsheet.java
+++ b/src/main/java/me/dodas/financeplanner/models/Spreadsheet.java
@@ -60,6 +60,9 @@ public class Spreadsheet {
         return null;
     }
 
+    /* Caso não tenha nenhum monthly register salvo no arquivo Json, ao desserializar a lista monthlyRegister fica null.
+     * Ou seja, é necessário fazer uma verificação toda vez que essa função for chamada.
+    */
     public List<MonthlyRegister> getMonthlyRegister(){
         return monthlyRegisters;
     }

--- a/src/main/java/me/dodas/financeplanner/utils/MonthlyRegisterAdapter.java
+++ b/src/main/java/me/dodas/financeplanner/utils/MonthlyRegisterAdapter.java
@@ -1,0 +1,48 @@
+package me.dodas.financeplanner.utils;
+
+import java.lang.reflect.Type;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import me.dodas.financeplanner.models.Expense;
+import me.dodas.financeplanner.models.MonthlyRegister;
+import me.dodas.financeplanner.models.Revenue;
+
+public class MonthlyRegisterAdapter implements JsonDeserializer<MonthlyRegister> {
+
+    @Override
+    public MonthlyRegister deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jdc)
+            throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+        // Json array de registros, podendo ser array de expenses ou revenues
+        JsonArray registryArray;
+
+        String mrId = jsonObject.get("id").getAsString();
+        MonthlyRegister monthlyRegister = new MonthlyRegister(mrId);
+        
+        // Desserialização de Revenue
+        registryArray = jsonObject.getAsJsonArray("revenues");
+        if (registryArray != null) {
+            for(JsonElement element : registryArray) {
+                monthlyRegister.addRevenue(jdc.deserialize(element, Revenue.class));
+            }
+        }
+
+        // Desserialização de Expense
+        registryArray = jsonObject.getAsJsonArray("expenses");
+        if (registryArray != null) {
+            for(JsonElement element : registryArray) {
+                monthlyRegister.addExpense(jdc.deserialize(element, Expense.class));
+            }
+        }
+
+        return monthlyRegister;
+    }
+    
+}


### PR DESCRIPTION
When deserializing the `Spreadsheet` class, `Gson` was having problems deserializing the `MonthlyRegister` class, due to an abstract class (`Registry`). Because of this, the `MonthlyRegisterAdapter` class was created, which aims to deserialize it correctly.